### PR TITLE
Bugfix/memory leak clear ownership

### DIFF
--- a/src/FileDownloader.cpp
+++ b/src/FileDownloader.cpp
@@ -97,15 +97,15 @@ void FileDownloader::replyFinished(QNetworkReply *reply)
     this->currentSegment->downloadProgress    = 100.0;
     this->currentSegment->downloadFinished    = true;
     this->currentSegment->compressedSizeBytes = this->currentSegment->compressedData.size();
+    this->state = State::Idle;
     emit downloadOfSegmentFinished();
   }
   else
   {
+    this->state = State::Idle;
     emit downloadOfFirstSPSSegmentFinished(reply->readAll());
     this->downloadNextFile();
   }
-
-  this->state = State::Idle;
 }
 
 void FileDownloader::updateDownloadProgress(int64_t val, int64_t max)

--- a/src/FileDownloader.h
+++ b/src/FileDownloader.h
@@ -86,7 +86,7 @@ private:
   };
   void downloadFile(FileType fileType);
 
-  SegmentBuffer::SegmentPtr currentSegment;
+  Segment *currentSegment{};
 
   bool isLocalSource{false};
 

--- a/src/FileDownloader.h
+++ b/src/FileDownloader.h
@@ -57,9 +57,10 @@ public:
   QString getStatus() const;
 
 signals:
-  void downloadFinished();
+  void downloadOfSegmentFinished();
+  void downloadOfFirstSPSSegmentFinished(QByteArray segmentData);
 
-private slots:
+public slots:
   void downloadNextFile();
 
   void replyFinished(QNetworkReply *reply);

--- a/src/FileDownloader.h
+++ b/src/FileDownloader.h
@@ -70,11 +70,24 @@ private:
   SegmentBuffer *segmentBuffer{};
   ManifestFile * manifestFile{};
 
+  enum class State
+  {
+    Idle,
+    DownloadSegment,
+    DownloadHighestResolutionSPS
+  };
+  State state{State::Idle};
+
+  enum class FileType
+  {
+    NextSegment,
+    HighestRepresentationSPS
+  };
+  void downloadFile(FileType fileType);
+
   SegmentBuffer::SegmentPtr currentSegment;
 
   bool isLocalSource{false};
-
-  QString statusText;
 
   QNetworkAccessManager networkManager;
 };

--- a/src/ManifestFile.cpp
+++ b/src/ManifestFile.cpp
@@ -49,11 +49,11 @@ Size parseResolutionString(QString resolutionString)
   return {width, height};
 }
 
-Segment::PlaybackInfo createPlaybackInfoForRendition(const ManifestFile::Rendition &rendition,
-                                                     unsigned                       currentSegment,
-                                                     unsigned currentRendition)
+Segment::SegmentInfo createSegmentInfoForRendition(const ManifestFile::Rendition &rendition,
+                                                   unsigned                       currentSegment,
+                                                   unsigned                       currentRendition)
 {
-  Segment::PlaybackInfo segmentInfo;
+  Segment::SegmentInfo segmentInfo;
   segmentInfo.segmentNumber = currentSegment;
   segmentInfo.rendition     = currentRendition;
   segmentInfo.fps           = rendition.fps;
@@ -138,6 +138,9 @@ bool ManifestFile::openFromData(QByteArray data)
       this->openGopAdaptiveResolutionChange =
           mainObject["OpenGOPAdaptiveResolutionChange"].toBool();
 
+    if (mainObject.contains("MaxSegmentBufferSize"))
+      this->maxSegmentBufferSize = size_t(mainObject["MaxSegmentBufferSize"].toInt());
+
     for (auto renditionValue : renditions)
     {
       if (!renditionValue.isObject())
@@ -196,12 +199,12 @@ std::optional<ManifestFile::Rendition> ManifestFile::getCurrentRenditionInfo() c
   return this->renditions.at(id);
 }
 
-Segment::PlaybackInfo ManifestFile::getNextSegment()
+Segment::SegmentInfo ManifestFile::getNextSegmentInfo()
 {
   auto &rendition = this->renditions.at(this->currentRendition);
 
   auto segmentInfo =
-      createPlaybackInfoForRendition(rendition, this->currentSegment, this->currentRendition);
+      createSegmentInfoForRendition(rendition, this->currentSegment, this->currentRendition);
 
   this->currentSegment++;
   if (this->currentSegment >= this->numberSegments)
@@ -210,8 +213,8 @@ Segment::PlaybackInfo ManifestFile::getNextSegment()
   return segmentInfo;
 }
 
-Segment::PlaybackInfo ManifestFile::getSegmentSPSHighestRendition()
+Segment::SegmentInfo ManifestFile::getSegmentSPSHighestRendition()
 {
   auto &rendition = this->renditions.back();
-  return createPlaybackInfoForRendition(rendition, 0, unsigned(this->renditions.size()) - 1);
+  return createSegmentInfoForRendition(rendition, 0, unsigned(this->renditions.size()) - 1);
 }

--- a/src/ManifestFile.cpp
+++ b/src/ManifestFile.cpp
@@ -49,6 +49,22 @@ Size parseResolutionString(QString resolutionString)
   return {width, height};
 }
 
+Segment::PlaybackInfo createPlaybackInfoForRendition(const ManifestFile::Rendition &rendition,
+                                                     unsigned                       currentSegment,
+                                                     unsigned currentRendition)
+{
+  Segment::PlaybackInfo segmentInfo;
+  segmentInfo.segmentNumber = currentSegment;
+  segmentInfo.rendition     = currentRendition;
+  segmentInfo.fps           = rendition.fps;
+
+  auto url = rendition.url;
+  url.replace("%i", QString("%1").arg(currentSegment));
+  segmentInfo.downloadUrl = url;
+
+  return segmentInfo;
+}
+
 const auto PREDEFINED_MANIFEST_0 = QByteArray(
     R"--json--({
     "Name": "Sintel 720p only",
@@ -118,6 +134,10 @@ bool ManifestFile::openFromData(QByteArray data)
       throw std::logic_error("No renditions found");
     auto renditions = mainObject["Renditions"].toArray();
 
+    if (mainObject.contains("OpenGOPAdaptiveResolutionChange"))
+      this->openGopAdaptiveResolutionChange =
+          mainObject["OpenGOPAdaptiveResolutionChange"].toBool();
+
     for (auto renditionValue : renditions)
     {
       if (!renditionValue.isObject())
@@ -180,18 +200,18 @@ Segment::PlaybackInfo ManifestFile::getNextSegment()
 {
   auto &rendition = this->renditions.at(this->currentRendition);
 
-  Segment::PlaybackInfo segmentInfo;
-  segmentInfo.segmentNumber = this->currentSegment;
-  segmentInfo.rendition     = this->currentRendition;
-  segmentInfo.fps           = rendition.fps;
-
-  auto url = rendition.url;
-  url.replace("%i", QString("%1").arg(this->currentSegment));
-  segmentInfo.downloadUrl = url;
+  auto segmentInfo =
+      createPlaybackInfoForRendition(rendition, this->currentSegment, this->currentRendition);
 
   this->currentSegment++;
   if (this->currentSegment >= this->numberSegments)
     this->currentSegment = 0;
 
   return segmentInfo;
+}
+
+Segment::PlaybackInfo ManifestFile::getSegmentSPSHighestRendition()
+{
+  auto &rendition = this->renditions.back();
+  return createPlaybackInfoForRendition(rendition, 0, unsigned(this->renditions.size()) - 1);
 }

--- a/src/ManifestFile.h
+++ b/src/ManifestFile.h
@@ -54,10 +54,11 @@ public:
   std::vector<Rendition>   getRenditionInfos() const { return this->renditions; }
   std::optional<Rendition> getCurrentRenditionInfo() const;
   unsigned                 getPlotMaxBitrate() const { return this->plotMaxBitrate; }
-  bool isopenGopAdaptiveResolutionChange() const { return this->openGopAdaptiveResolutionChange; }
+  bool   isopenGopAdaptiveResolutionChange() const { return this->openGopAdaptiveResolutionChange; }
+  size_t getMaxSegmentBufferSize() const { return this->maxSegmentBufferSize; }
 
-  Segment::PlaybackInfo getNextSegment();
-  Segment::PlaybackInfo getSegmentSPSHighestRendition();
+  Segment::SegmentInfo getNextSegmentInfo();
+  Segment::SegmentInfo getSegmentSPSHighestRendition();
 
 private:
   ILogger *logger{};
@@ -70,6 +71,7 @@ private:
   unsigned numberSegments{};
   unsigned plotMaxBitrate{};
   bool     openGopAdaptiveResolutionChange{};
+  size_t   maxSegmentBufferSize{5};
 
   std::vector<Rendition> renditions;
 

--- a/src/ManifestFile.h
+++ b/src/ManifestFile.h
@@ -54,8 +54,10 @@ public:
   std::vector<Rendition>   getRenditionInfos() const { return this->renditions; }
   std::optional<Rendition> getCurrentRenditionInfo() const;
   unsigned                 getPlotMaxBitrate() const { return this->plotMaxBitrate; }
+  bool isopenGopAdaptiveResolutionChange() const { return this->openGopAdaptiveResolutionChange; }
 
   Segment::PlaybackInfo getNextSegment();
+  Segment::PlaybackInfo getSegmentSPSHighestRendition();
 
 private:
   ILogger *logger{};
@@ -67,6 +69,7 @@ private:
   QString  name{"NoName"};
   unsigned numberSegments{};
   unsigned plotMaxBitrate{};
+  bool     openGopAdaptiveResolutionChange{};
 
   std::vector<Rendition> renditions;
 

--- a/src/PlaybackController.cpp
+++ b/src/PlaybackController.cpp
@@ -70,7 +70,11 @@ bool PlaybackController::openJsonManifestFile(QString jsonManifestFile)
   this->manifestFile = std::make_unique<ManifestFile>(this->logger);
   auto success       = this->manifestFile->openJsonManifestFile(jsonManifestFile);
   if (success)
+  {
     this->downloader->activateManifest(this->manifestFile.get());
+    this->decoder->setOpenGopAdaptiveResolutionChange(
+        this->manifestFile->isopenGopAdaptiveResolutionChange());
+  }
   return success;
 }
 
@@ -79,7 +83,11 @@ bool PlaybackController::openPredefinedManifest(unsigned predefinedManifestID)
   this->manifestFile = std::make_unique<ManifestFile>(this->logger);
   auto success       = this->manifestFile->openPredefinedManifest(predefinedManifestID);
   if (success)
+  {
     this->downloader->activateManifest(this->manifestFile.get());
+    this->decoder->setOpenGopAdaptiveResolutionChange(
+        this->manifestFile->isopenGopAdaptiveResolutionChange());
+  }
   return success;
 }
 

--- a/src/PlaybackController.h
+++ b/src/PlaybackController.h
@@ -37,7 +37,7 @@ SOFTWARE. */
 
 class PlaybackController : public QObject
 {
-Q_OBJECT
+  Q_OBJECT
 
 public:
   PlaybackController(ILogger *logger);
@@ -55,7 +55,7 @@ public:
   QString getStatus();
   auto    getLastSegmentsData() -> std::deque<SegmentData>;
 
-  SegmentBuffer *getSegmentBuffer() { return &this->segmentBuffer; }
+  SegmentBuffer *getSegmentBuffer() { return this->segmentBuffer.get(); }
   ManifestFile * getManifest() { return this->manifestFile.get(); }
 
 private:
@@ -65,8 +65,7 @@ private:
   std::unique_ptr<DecoderThread>         decoder;
   std::unique_ptr<FileParserThread>      parser;
   std::unique_ptr<FrameConversionThread> conversion;
+  std::unique_ptr<SegmentBuffer>         segmentBuffer;
 
   std::unique_ptr<ManifestFile> manifestFile;
-
-  SegmentBuffer segmentBuffer;
 };

--- a/src/PlaybackController.h
+++ b/src/PlaybackController.h
@@ -58,7 +58,13 @@ public:
   SegmentBuffer *getSegmentBuffer() { return this->segmentBuffer.get(); }
   ManifestFile * getManifest() { return this->manifestFile.get(); }
 
+private slots:
+  void downloadOfSegmentFinished();
+  void fillDownloadQueue();
+
 private:
+  void activateManifest();
+
   ILogger *logger{};
 
   std::unique_ptr<FileDownloader>        downloader;
@@ -66,6 +72,8 @@ private:
   std::unique_ptr<FileParserThread>      parser;
   std::unique_ptr<FrameConversionThread> conversion;
   std::unique_ptr<SegmentBuffer>         segmentBuffer;
+
+  std::unique_ptr<Segment> highestRenditionFirstSegment;
 
   std::unique_ptr<ManifestFile> manifestFile;
 };

--- a/src/PlaybackController.h
+++ b/src/PlaybackController.h
@@ -33,9 +33,12 @@ SOFTWARE. */
 #include <threads/FrameConversionThread.h>
 
 #include <QDir>
+#include <QObject>
 
-class PlaybackController
+class PlaybackController : public QObject
 {
+Q_OBJECT
+
 public:
   PlaybackController(ILogger *logger);
   ~PlaybackController();

--- a/src/SegmentBuffer.cpp
+++ b/src/SegmentBuffer.cpp
@@ -152,7 +152,7 @@ SegmentBuffer::FramePt SegmentBuffer::addNewFrameToSegment(SegmentPtr segment)
   return newFrame;
 }
 
-void SegmentBuffer::onDownloadFinished()
+void SegmentBuffer::onDownloadOfSegmentFinished()
 {
   this->eventCV.notify_all();
   this->tryToStartNextDownload();

--- a/src/SegmentBuffer.cpp
+++ b/src/SegmentBuffer.cpp
@@ -36,26 +36,36 @@ SOFTWARE. */
 namespace
 {
 
-SegmentBuffer::SegmentPtr getNextSegmentFromQueue(SegmentBuffer::SegmentPtr          curSegment,
-                                                  const SegmentBuffer::SegmentDeque &segments)
+Segment *getNextSegmentFromQueue(Segment *                             curSegment,
+                                 std::deque<std::unique_ptr<Segment>> &segments)
 {
-  auto segmentIt = std::find(segments.begin(), segments.end(), curSegment);
+  auto segmentIt = std::find_if(
+      segments.begin(), segments.end(), [&curSegment](const std::unique_ptr<Segment> &segment) {
+        return segment.get() == curSegment;
+      });
   if (segmentIt == segments.end())
     return {};
   segmentIt++;
   if (segmentIt == segments.end())
     return {};
-  return *segmentIt;
+  return segmentIt->get();
 }
 
-SegmentBuffer::FrameIterator getNextFrame(const SegmentBuffer::FrameIterator &frame,
-                                          const SegmentBuffer::SegmentDeque & segments)
+SegmentBuffer::FrameIterator getNextFrame(const SegmentBuffer::FrameIterator &  frameIterator,
+                                          std::deque<std::unique_ptr<Segment>> &segments)
 {
-  auto segmentIt = std::find(segments.begin(), segments.end(), frame.segment);
+  auto segmentIt = std::find_if(
+      segments.begin(), segments.end(), [&frameIterator](const std::unique_ptr<Segment> &segment) {
+        return segment.get() == frameIterator.segment;
+      });
   if (segmentIt == segments.end())
     return {};
   auto &segmentFrames  = (*segmentIt)->frames;
-  auto  segmentFrameIt = std::find(segmentFrames.begin(), segmentFrames.end(), frame.frame);
+  auto  segmentFrameIt = std::find_if(segmentFrames.begin(),
+                                     segmentFrames.end(),
+                                     [&frameIterator](const std::unique_ptr<Frame> &frame) {
+                                       return frame.get() == frameIterator.frame;
+                                     });
   if (segmentFrameIt == segmentFrames.end())
     return {};
   auto nextFrameInSegment = (++segmentFrameIt);
@@ -66,9 +76,9 @@ SegmentBuffer::FrameIterator getNextFrame(const SegmentBuffer::FrameIterator &fr
       return {};
     if ((*nextSegment)->frames.size() == 0)
       return {};
-    return {*nextSegment, (*nextSegment)->frames.front()};
+    return {nextSegment->get(), (*nextSegment)->frames.front().get()};
   }
-  return {frame.segment, *nextFrameInSegment};
+  return {frameIterator.segment, nextFrameInSegment->get()};
 }
 
 } // namespace
@@ -83,7 +93,7 @@ void SegmentBuffer::abort()
 }
 
 std::vector<SegmentBuffer::SegmentRenderInfo>
-SegmentBuffer::getBufferStatusForRender(FramePt curPlaybackFrame)
+SegmentBuffer::getBufferStatusForRender(Frame *curPlaybackFrame)
 {
   std::unique_lock               lk(this->segmentQueueMutex);
   std::vector<SegmentRenderInfo> states;
@@ -102,7 +112,7 @@ SegmentBuffer::getBufferStatusForRender(FramePt curPlaybackFrame)
       frameInfo.frameState  = frame->frameState;
       frameInfo.sizeInBytes = frame->nrBytesCompressed;
       segmentInfo.frameInfo.push_back(frameInfo);
-      if (frame == curPlaybackFrame)
+      if (frame.get() == curPlaybackFrame)
         segmentInfo.indexOfCurFrameInFrames = frameCounter;
       frameCounter++;
     }
@@ -111,7 +121,7 @@ SegmentBuffer::getBufferStatusForRender(FramePt curPlaybackFrame)
   return states;
 }
 
-SegmentBuffer::SegmentPtr SegmentBuffer::getNextDownloadSegment()
+Segment *SegmentBuffer::getNextDownloadSegment()
 {
   DEBUG("SegmentBuffer: Get next segment");
 
@@ -121,35 +131,31 @@ SegmentBuffer::SegmentPtr SegmentBuffer::getNextDownloadSegment()
     return {};
   }
 
-  SegmentPtr newSegment;
   if (this->segmentRecycleBin.empty())
-    newSegment = std::make_shared<Segment>();
+    this->segments.emplace_back();
   else
   {
-    newSegment = this->segmentRecycleBin.front();
+    this->segments.push_back(std::move(this->segmentRecycleBin.front()));
     this->segmentRecycleBin.pop();
   }
 
-  this->segments.push_back(newSegment);
-  return newSegment;
+  return this->segments.back().get();
 }
 
-SegmentBuffer::FramePt SegmentBuffer::addNewFrameToSegment(SegmentPtr segment)
+Frame *SegmentBuffer::addNewFrameToSegment(Segment *segment)
 {
   std::shared_lock lk(this->segmentQueueMutex);
 
-  FramePt newFrame;
   if (this->frameRecycleBin.empty())
-    newFrame = std::make_shared<Frame>();
+    segment->frames.emplace_back();
   else
   {
-    newFrame = this->frameRecycleBin.front();
+    segment->frames.push_back(std::move(this->frameRecycleBin.front()));
     this->frameRecycleBin.pop();
   }
 
-  segment->frames.push_back(newFrame);
   segment->nrFrames++;
-  return newFrame;
+  return segment->frames.back().get();
 }
 
 void SegmentBuffer::onDownloadOfSegmentFinished()
@@ -158,7 +164,7 @@ void SegmentBuffer::onDownloadOfSegmentFinished()
   this->tryToStartNextDownload();
 }
 
-SegmentBuffer::SegmentPtr SegmentBuffer::getFirstSegmentToParse()
+Segment *SegmentBuffer::getFirstSegmentToParse()
 {
   DEBUG("SegmentBuffer: Waiting for first segment to parse.");
   this->eventCV.notify_all();
@@ -179,10 +185,10 @@ SegmentBuffer::SegmentPtr SegmentBuffer::getFirstSegmentToParse()
   }
 
   DEBUG("SegmentBuffer: First segment to parse ready");
-  return *this->segments.begin();
+  return this->segments.begin()->get();
 }
 
-SegmentBuffer::SegmentPtr SegmentBuffer::getNextSegmentToParse(SegmentPtr segmentPtr)
+Segment *SegmentBuffer::getNextSegmentToParse(Segment *segmentPtr)
 {
   DEBUG("SegmentBuffer: Waiting for next segment to parse");
   this->eventCV.notify_all();
@@ -206,7 +212,7 @@ SegmentBuffer::SegmentPtr SegmentBuffer::getNextSegmentToParse(SegmentPtr segmen
   return getNextSegmentFromQueue(segmentPtr, this->segments);
 }
 
-SegmentBuffer::SegmentPtr SegmentBuffer::getFirstSegmentToDecode()
+Segment *SegmentBuffer::getFirstSegmentToDecode()
 {
   DEBUG("SegmentBuffer: Waiting for first segment to decode.");
   this->eventCV.notify_all();
@@ -227,10 +233,10 @@ SegmentBuffer::SegmentPtr SegmentBuffer::getFirstSegmentToDecode()
   }
 
   DEBUG("SegmentBuffer: First segment to decode ready");
-  return *this->segments.begin();
+  return this->segments.begin()->get();
 }
 
-SegmentBuffer::SegmentPtr SegmentBuffer::getNextSegmentToDecode(SegmentPtr segmentPtr)
+Segment *SegmentBuffer::getNextSegmentToDecode(Segment *segmentPtr)
 {
   DEBUG("SegmentBuffer: Waiting for next segment to decode");
   this->eventCV.notify_all();
@@ -282,7 +288,7 @@ SegmentBuffer::FrameIterator SegmentBuffer::getFirstFrameToConvert()
   }
 
   DEBUG("SegmentBuffer: First frame to convert ready");
-  return {this->segments.front(), this->segments.front()->frames.front()};
+  return {this->segments.front().get(), this->segments.front()->frames.front().get()};
 }
 
 SegmentBuffer::FrameIterator SegmentBuffer::getNextFrameToConvert(FrameIterator frameIt)
@@ -337,7 +343,7 @@ SegmentBuffer::FrameIterator SegmentBuffer::getFirstFrameToDisplay()
 
   DEBUG("First frame to display ready.");
   this->eventCV.notify_all();
-  return {firstSegment, firstSegment->frames.front()};
+  return {firstSegment.get(), firstSegment->frames.front().get()};
 }
 
 SegmentBuffer::FrameIterator SegmentBuffer::getNextFrameToDisplay(FrameIterator frameIt)
@@ -361,9 +367,9 @@ SegmentBuffer::FrameIterator SegmentBuffer::getNextFrameToDisplay(FrameIterator 
 
   if (frameIt.segment != nextFrame.segment)
   {
-    assert(frameIt.segment == this->segments.front());
+    assert(frameIt.segment == this->segments.front().get());
+    this->recycleSegmentAndFrames(std::move(this->segments.front()));
     this->segments.pop_front();
-    this->recycleSegmentAndFrames(frameIt.segment);
     this->tryToStartNextDownload();
   }
 
@@ -379,13 +385,13 @@ void SegmentBuffer::tryToStartNextDownload()
     emit startNextDownload();
 }
 
-void SegmentBuffer::recycleSegmentAndFrames(SegmentPtr segment)
+void SegmentBuffer::recycleSegmentAndFrames(std::unique_ptr<Segment> &&segment)
 {
-  for (auto frameIt : segment->frames)
+  for (auto &frameIt : segment->frames)
   {
     frameIt->clear();
-    this->frameRecycleBin.push(frameIt);
+    this->frameRecycleBin.push(std::move(frameIt));
   }
   segment->clear();
-  this->segmentRecycleBin.push(segment);
+  this->segmentRecycleBin.push(std::move(segment));
 }

--- a/src/SegmentBuffer.h
+++ b/src/SegmentBuffer.h
@@ -79,6 +79,8 @@ public:
   };
   std::vector<SegmentRenderInfo> getBufferStatusForRender(Frame *curPlaybackFrame);
 
+  size_t getNrOfBufferedSegments();
+
   // These provide new (or maybe recycled) segments/frames. These do not block.
   Segment *getNextDownloadSegment();
   Frame *  addNewFrameToSegment(Segment *segment);
@@ -102,15 +104,12 @@ public:
   FrameIterator getFirstFrameToDisplay();
   FrameIterator getNextFrameToDisplay(FrameIterator frameIt);
 
-signals:
-  void startNextDownload();
-
-public slots:
   void onDownloadOfSegmentFinished();
 
-private:
-  void tryToStartNextDownload();
+signals:
+  void segmentRemovedFromBuffer();
 
+private:
   std::deque<std::unique_ptr<Segment>> segments;
 
   std::condition_variable_any eventCV;

--- a/src/SegmentBuffer.h
+++ b/src/SegmentBuffer.h
@@ -109,7 +109,7 @@ signals:
   void startNextDownload();
 
 public slots:
-  void onDownloadFinished();
+  void onDownloadOfSegmentFinished();
 
 private:
   void tryToStartNextDownload();

--- a/src/SegmentBuffer.h
+++ b/src/SegmentBuffer.h
@@ -29,6 +29,7 @@ SOFTWARE. */
 #include <condition_variable>
 #include <deque>
 #include <iterator>
+#include <optional>
 #include <queue>
 #include <shared_mutex>
 
@@ -51,17 +52,13 @@ public:
 
   void abort();
 
-  using FramePt      = std::shared_ptr<Frame>;
-  using SegmentPtr   = std::shared_ptr<Segment>;
-  using SegmentDeque = std::deque<SegmentPtr>;
-
   struct FrameIterator
   {
     FrameIterator() = default;
-    FrameIterator(SegmentPtr segment, FramePt frame) : segment(segment), frame(frame) {}
-    bool       isNull() { return this->segment == nullptr || this->frame == nullptr; }
-    SegmentPtr segment;
-    FramePt    frame;
+    FrameIterator(Segment *segment, Frame *frame) : segment(segment), frame(frame) {}
+    bool     isNull() { return this->segment == nullptr || this->frame == nullptr; }
+    Segment *segment{};
+    Frame *  frame{};
   };
 
   struct SegmentRenderInfo
@@ -80,21 +77,21 @@ public:
     };
     std::vector<FrameInfo> frameInfo;
   };
-  std::vector<SegmentRenderInfo> getBufferStatusForRender(FramePt curPlaybackFrame);
+  std::vector<SegmentRenderInfo> getBufferStatusForRender(Frame *curPlaybackFrame);
 
   // These provide new (or maybe recycled) segments/frames. These do not block.
-  SegmentPtr getNextDownloadSegment();
-  FramePt    addNewFrameToSegment(SegmentPtr segment);
+  Segment *getNextDownloadSegment();
+  Frame *  addNewFrameToSegment(Segment *segment);
 
   // The parser will get segments to parser here (and may get blocked if no segment is ready yet)
-  SegmentPtr getFirstSegmentToParse();
-  SegmentPtr getNextSegmentToParse(SegmentPtr segment);
+  Segment *getFirstSegmentToParse();
+  Segment *getNextSegmentToParse(Segment *segment);
 
   // The decoder will get segments to decode here (and may get blocked if too many
   // decoded frames are already in the buffer)
-  SegmentPtr getFirstSegmentToDecode();
-  SegmentPtr getNextSegmentToDecode(SegmentPtr segment);
-  void       onFrameDecoded();
+  Segment *getFirstSegmentToDecode();
+  Segment *getNextSegmentToDecode(Segment *segment);
+  void     onFrameDecoded();
 
   // The converter will get frames to convert here (and may get blocked if there
   // are none)
@@ -114,14 +111,14 @@ public slots:
 private:
   void tryToStartNextDownload();
 
-  SegmentDeque segments;
+  std::deque<std::unique_ptr<Segment>> segments;
 
   std::condition_variable_any eventCV;
   std::shared_mutex           segmentQueueMutex;
 
   bool aborted{false};
 
-  void                   recycleSegmentAndFrames(SegmentPtr segment);
-  std::queue<SegmentPtr> segmentRecycleBin;
-  std::queue<FramePt>    frameRecycleBin;
+  void                                 recycleSegmentAndFrames(std::unique_ptr<Segment> &&segment);
+  std::queue<std::unique_ptr<Segment>> segmentRecycleBin;
+  std::queue<std::unique_ptr<Frame>>   frameRecycleBin;
 };

--- a/src/common/Frame.h
+++ b/src/common/Frame.h
@@ -35,8 +35,11 @@ enum class FrameState
   Empty
 };
 
-struct Frame
+class Frame
 {
+public:
+  Frame() = default;
+
   void clear()
   {
     this->frameState        = FrameState::Empty;

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -32,12 +32,12 @@ SOFTWARE. */
 class Segment
 {
 public:
-  Segment() = default;
+  Segment()  = default;
   ~Segment() = default;
 
   void clear()
   {
-    this->playbackInfo        = {};
+    this->segmentInfo         = {};
     this->compressedSizeBytes = 0;
     this->downloadProgress    = 0.0;
     this->downloadFinished    = false;
@@ -46,14 +46,14 @@ public:
     this->frames.clear();
   }
 
-  struct PlaybackInfo
+  struct SegmentInfo
   {
     unsigned segmentNumber{};
     unsigned rendition{};
     QString  downloadUrl;
     double   fps{};
   };
-  PlaybackInfo playbackInfo{};
+  SegmentInfo segmentInfo{};
 
   QByteArray  compressedData;
   std::size_t compressedSizeBytes{0};

--- a/src/common/Segment.h
+++ b/src/common/Segment.h
@@ -29,8 +29,12 @@ SOFTWARE. */
 #include <QString>
 #include <memory>
 
-struct Segment
+class Segment
 {
+public:
+  Segment() = default;
+  ~Segment() = default;
+
   void clear()
   {
     this->playbackInfo        = {};
@@ -62,5 +66,5 @@ struct Segment
 
   unsigned nrFrames{0};
 
-  std::vector<std::shared_ptr<Frame>> frames;
+  std::vector<std::unique_ptr<Frame>> frames;
 };

--- a/src/decoder/decoderVVDec.cpp
+++ b/src/decoder/decoderVVDec.cpp
@@ -370,17 +370,12 @@ bool decoderVVDec::getNextFrameFromDecoder()
       DEBUG_vvdec("decoderVVDec::getNextFrameFromDecoder plane has different size then expected");
   }
 
-  if (!this->frameSize.isValid() && !this->formatYUV.isValid())
-  {
-    // Set the values
-    this->frameSize = lumaSize;
+  this->frameSize = lumaSize;
+  if (!this->formatYUV.isValid())
     this->formatYUV = YUV_Internals::YUVPixelFormat(subsampling, bitDepth);
-  }
   else
   {
     // Check the values against the previously set values
-    if (this->frameSize != lumaSize)
-      return setErrorB("Received a frame of different size");
     if (this->formatYUV.getSubsampling() != subsampling)
       return setErrorB("Received a frame with different subsampling");
     if (unsigned(this->formatYUV.getBitsPerSample()) != bitDepth)

--- a/src/decoder/decoderVVDec.cpp
+++ b/src/decoder/decoderVVDec.cpp
@@ -172,18 +172,10 @@ void decoderVVDec::resolveLibraryFunctionPointers()
     return;
   if (!resolve(this->lib.vvdec_accessUnit_alloc_payload, "vvdec_accessUnit_alloc_payload"))
     return;
-  if (!resolve(this->lib.vvdec_accessUnit_free_payload, "vvdec_accessUnit_free_payload"))
-    return;
   if (!resolve(this->lib.vvdec_accessUnit_default, "vvdec_accessUnit_default"))
     return;
 
   if (!resolve(this->lib.vvdec_params_default, "vvdec_params_default"))
-    return;
-  if (!resolve(this->lib.vvdec_params_alloc, "vvdec_params_alloc"))
-    return;
-  if (!resolve(this->lib.vvdec_params_alloc, "vvdec_params_alloc"))
-    return;
-  if (!resolve(this->lib.vvdec_params_free, "vvdec_params_free"))
     return;
 
   if (!resolve(this->lib.vvdec_decoder_open, "vvdec_decoder_open"))
@@ -450,11 +442,14 @@ QByteArray decoderVVDec::getRawFrameData()
     return {};
   }
 
-  if (this->currentOutputBuffer.isEmpty())
+  if (this->currentFrame && this->currentOutputBuffer.isEmpty())
   {
     // Put image data into buffer
     copyImgToByteArray(this->currentOutputBuffer);
     DEBUG_vvdec("decoderVVDec::getRawFrameData copied frame to buffer");
+
+    this->lib.vvdec_frame_unref(this->decoder, this->currentFrame);
+    this->currentFrame = nullptr;
   }
 
   return currentOutputBuffer;

--- a/src/decoder/decoderVVDec.cpp
+++ b/src/decoder/decoderVVDec.cpp
@@ -34,9 +34,9 @@ SOFTWARE. */
 #define decoderVVDec_DEBUG_OUTPUT 0
 #if decoderVVDec_DEBUG_OUTPUT
 #include <QDebug>
-#define DEBUG_vvdec qDebug
+#define DEBUG_vvdec(msg) qDebug() << msg
 #else
-#define DEBUG_vvdec(fmt, ...) ((void)0)
+#define DEBUG_vvdec(msg) ((void)0)
 #endif
 
 // Restrict is basically a promise to the compiler that for the scope of the pointer, the target of
@@ -243,7 +243,7 @@ void decoderVVDec::allocateNewDecoder()
   if (this->decoder != nullptr)
     return;
 
-  DEBUG_vvdec("decoderVVDec::allocateNewDecoder - decodeSignal %d", decodeSignal);
+  DEBUG_vvdec("decoderVVDec::allocateNewDecoder - decodeSignal " << decodeSignal);
 
   vvdecParams params;
   this->lib.vvdec_params_default(&params);
@@ -301,8 +301,8 @@ bool decoderVVDec::decodeNextFrame()
     }
     else if (ret != VVDEC_OK)
       return setErrorB("Error sendling flush to decoder");
-    DEBUG_vvdec("decoderVVDec::pushData: Flushing to next pixture. %s",
-                this->currentFrame != nullptr ? " frameAvailable" : "");
+    DEBUG_vvdec("decoderVVDec::pushData: Flushing to next pixture. "
+                << (this->currentFrame != nullptr ? " frameAvailable" : ""));
 
     if (this->currentFrame == nullptr)
     {
@@ -341,6 +341,10 @@ bool decoderVVDec::getNextFrameFromDecoder()
     DEBUG_vvdec("decoderVVDec::getNextFrameFromDecoder No frame decoded");
     return false;
   }
+
+  DEBUG_vvdec("decoderVVDec::getNextFrameFromDecoder got frame CTS "
+              << this->currentFrame->cts << " sequenceNumber " << this->currentFrame->sequenceNumber
+              << " ctsValid " << this->currentFrame->ctsValid);
 
   // Check the validity of the picture
   const auto lumaSize = Size({this->currentFrame->width, this->currentFrame->height});
@@ -430,9 +434,8 @@ bool decoderVVDec::pushData(QByteArray &data)
                            .arg(cErrAdd));
     }
 
-    DEBUG_vvdec("decoderVVDec::pushData pushed NAL length %d%s",
-                data.length(),
-                this->currentFrame != nullptr ? " frameAvailable" : "");
+    DEBUG_vvdec("decoderVVDec::pushData pushed NAL length "
+                << data.length() << (this->currentFrame != nullptr ? " frameAvailable" : ""));
   }
 
   if (this->getNextFrameFromDecoder())
@@ -479,7 +482,7 @@ void decoderVVDec::copyImgToByteArray(QByteArray &dst)
   auto outSizeChromaBytes = chromaSize.width * chromaSize.height * bytesPerSample;
   // How many bytes do we need in the output buffer?
   auto nrBytesOutput = (outSizeLumaBytes + outSizeChromaBytes * 2);
-  DEBUG_vvdec("decoderVVDec::copyImgToByteArray nrBytesOutput %d", nrBytesOutput);
+  DEBUG_vvdec("decoderVVDec::copyImgToByteArray nrBytesOutput " << nrBytesOutput);
 
   // Is the output big enough?
   if (dst.capacity() < int(nrBytesOutput))
@@ -494,7 +497,7 @@ void decoderVVDec::copyImgToByteArray(QByteArray &dst)
 
     if (component.ptr == nullptr)
     {
-      DEBUG_vvdec("decoderVVDec::copyImgToByteArray unable to get plane for component %d", c);
+      DEBUG_vvdec("decoderVVDec::copyImgToByteArray unable to get plane for component " << c);
       return;
     }
 

--- a/src/decoder/decoderVVDec.h
+++ b/src/decoder/decoderVVDec.h
@@ -39,12 +39,9 @@ struct LibraryFunctionsVVDec
   vvdecAccessUnit *(*vvdec_accessUnit_alloc)(){};
   void (*vvdec_accessUnit_free)(vvdecAccessUnit *accessUnit){};
   void (*vvdec_accessUnit_alloc_payload)(vvdecAccessUnit *accessUnit, int payload_size){};
-  void (*vvdec_accessUnit_free_payload)(vvdecAccessUnit *accessUnit){};
   void (*vvdec_accessUnit_default)(vvdecAccessUnit *accessUnit){};
 
   void (*vvdec_params_default)(vvdecParams *param){};
-  vvdecParams *(*vvdec_params_alloc)(){};
-  void (*vvdec_params_free)(vvdecParams *params){};
 
   vvdecDecoder *(*vvdec_decoder_open)(vvdecParams *){};
   int (*vvdec_decoder_close)(vvdecDecoder *){};

--- a/src/threads/DecoderThread.cpp
+++ b/src/threads/DecoderThread.cpp
@@ -137,10 +137,10 @@ void DecoderThread::runDecoder()
 {
   this->logger->addMessage("Started decoder thread", LoggingPriority::Info);
 
-  size_t   currentDataOffset        = 0;
-  unsigned currentFrameIdxInSegment = 0;
-  auto     itSegmentData            = this->segmentBuffer->getFirstSegmentToDecode();
-  std::queue<SegmentBuffer::SegmentPtr> nextSegmentFrames;
+  size_t                currentDataOffset        = 0;
+  unsigned              currentFrameIdxInSegment = 0;
+  auto                  itSegmentData            = this->segmentBuffer->getFirstSegmentToDecode();
+  std::queue<Segment *> nextSegmentFrames;
   nextSegmentFrames.push(itSegmentData);
 
   while (!this->decoderAbort)
@@ -256,7 +256,7 @@ void DecoderThread::runDecoder()
             }
           }
 
-          auto frame         = itSegmentFrames->frames.at(currentFrameIdxInSegment);
+          auto &frame       = itSegmentFrames->frames.at(currentFrameIdxInSegment);
           frame->rawYUVData  = this->decoder->getRawFrameData();
           frame->pixelFormat = this->decoder->getYUVPixelFormat();
           frame->frameSize   = this->decoder->getFrameSize();

--- a/src/threads/DecoderThread.cpp
+++ b/src/threads/DecoderThread.cpp
@@ -205,6 +205,12 @@ void DecoderThread::runDecoder()
         }
         else
         {
+          if (!this->highestRenditionSPS.isEmpty() && isSPSNAL(nalData))
+          {
+            DEBUG("Replace SPS with SPS from highest rendition");
+            nalData = this->highestRenditionSPS;
+          }
+
           DEBUG("Pushing " << nalData.size() << " bytes");
           if (!this->decoder->pushData(nalData))
           {

--- a/src/threads/DecoderThread.cpp
+++ b/src/threads/DecoderThread.cpp
@@ -86,6 +86,11 @@ DecoderThread::~DecoderThread()
 
 void DecoderThread::abort() { this->decoderAbort = true; }
 
+void DecoderThread::setOpenGopAdaptiveResolutionChange(bool adaptiveResolutioChange)
+{
+  this->adaptiveResolutioChange = adaptiveResolutioChange;
+}
+
 QString DecoderThread::getStatus() const
 {
   return (this->decoderAbort ? "Abort " : "") + this->statusText;
@@ -102,7 +107,7 @@ void DecoderThread::onDownloadOfFirstSPSSegmentFinished(QByteArray segmentData)
   }
 
   size_t currentDataOffset = *startPos;
-  while (currentDataOffset < segmentData.size())
+  while (currentDataOffset < size_t(segmentData.size()))
   {
     QByteArray nalData;
     if (auto nextNalStart = findNextNalInData(segmentData, currentDataOffset + 3))
@@ -125,7 +130,7 @@ void DecoderThread::onDownloadOfFirstSPSSegmentFinished(QByteArray segmentData)
   }
 
   this->logger->addMessage("SPS could not be extracted from highest rendition",
-                             LoggingPriority::Error);
+                           LoggingPriority::Error);
 }
 
 void DecoderThread::runDecoder()
@@ -190,7 +195,7 @@ void DecoderThread::runDecoder()
           itSegmentData = nextSegment;
           nextSegmentFrames.push(nextSegment);
 
-          if (renditionSwitch)
+          if (renditionSwitch && !this->adaptiveResolutioChange)
           {
             resetDecoderAfterSegment = true;
             DEBUG("Pushing empty data (EOF)");

--- a/src/threads/DecoderThread.cpp
+++ b/src/threads/DecoderThread.cpp
@@ -186,11 +186,11 @@ void DecoderThread::runDecoder()
           }
 
           DEBUG(QString("Got next segment Rendition %1 Segment %2")
-                    .arg(nextSegment->playbackInfo.rendition)
-                    .arg(nextSegment->playbackInfo.segmentNumber));
+                    .arg(nextSegment->segmentInfo.rendition)
+                    .arg(nextSegment->segmentInfo.segmentNumber));
 
           auto renditionSwitch =
-              nextSegment->playbackInfo.rendition != itSegmentData->playbackInfo.rendition;
+              nextSegment->segmentInfo.rendition != itSegmentData->segmentInfo.rendition;
 
           itSegmentData = nextSegment;
           nextSegmentFrames.push(nextSegment);
@@ -266,8 +266,8 @@ void DecoderThread::runDecoder()
                     .arg(frame->frameSize.width)
                     .arg(frame->frameSize.height)
                     .arg(currentFrameIdxInSegment)
-                    .arg(itSegmentFrames->playbackInfo.segmentNumber)
-                    .arg(itSegmentFrames->playbackInfo.rendition));
+                    .arg(itSegmentFrames->segmentInfo.segmentNumber)
+                    .arg(itSegmentFrames->segmentInfo.rendition));
           this->segmentBuffer->onFrameDecoded();
           currentFrameIdxInSegment++;
         }
@@ -277,8 +277,8 @@ void DecoderThread::runDecoder()
       {
         DEBUG("Decoding error");
         this->logger->addMessage(QString("Error decoding rend %1 seg %2 frame %3")
-                                     .arg(itSegmentData->playbackInfo.rendition)
-                                     .arg(itSegmentData->playbackInfo.segmentNumber)
+                                     .arg(itSegmentData->segmentInfo.rendition)
+                                     .arg(itSegmentData->segmentInfo.segmentNumber)
                                      .arg(currentFrameIdxInSegment),
                                  LoggingPriority::Error);
         break;

--- a/src/threads/DecoderThread.h
+++ b/src/threads/DecoderThread.h
@@ -30,15 +30,21 @@ SOFTWARE. */
 #include <condition_variable>
 #include <optional>
 #include <thread>
+#include <QObject>
 
-class DecoderThread
+class DecoderThread : public QObject
 {
+Q_OBJECT
+
 public:
   DecoderThread(ILogger *logger, SegmentBuffer *segmentBuffer);
   ~DecoderThread();
   void abort();
 
   QString getStatus() const;
+
+public slots:
+  void onDownloadOfFirstSPSSegmentFinished(QByteArray segmentData);
 
 private:
   ILogger *      logger{};
@@ -50,6 +56,8 @@ private:
 
   std::thread decoderThread;
   bool        decoderAbort{false};
+
+  QByteArray highestRenditionSPS;
 
   QString statusText;
 };

--- a/src/threads/DecoderThread.h
+++ b/src/threads/DecoderThread.h
@@ -27,19 +27,21 @@ SOFTWARE. */
 #include <common/ILogger.h>
 #include <decoder/decoderBase.h>
 
+#include <QObject>
 #include <condition_variable>
 #include <optional>
 #include <thread>
-#include <QObject>
 
 class DecoderThread : public QObject
 {
-Q_OBJECT
+  Q_OBJECT
 
 public:
   DecoderThread(ILogger *logger, SegmentBuffer *segmentBuffer);
   ~DecoderThread();
   void abort();
+
+  void setOpenGopAdaptiveResolutionChange(bool adaptiveResolutioChange);
 
   QString getStatus() const;
 
@@ -55,7 +57,8 @@ private:
   std::unique_ptr<decoder::decoderBase> decoder;
 
   std::thread decoderThread;
-  bool        decoderAbort{false};
+  bool        decoderAbort{};
+  bool        adaptiveResolutioChange{};
 
   QByteArray highestRenditionSPS;
 

--- a/src/threads/FileParserThread.cpp
+++ b/src/threads/FileParserThread.cpp
@@ -114,7 +114,7 @@ void FileParserThread::runParser()
       {
         this->logger->addMessage(QString("Error parsing nal %1 in Segment %2")
                                      .arg(nalID)
-                                     .arg(segmentIt->playbackInfo.segmentNumber),
+                                     .arg(segmentIt->segmentInfo.segmentNumber),
                                  LoggingPriority::Error);
       }
 

--- a/src/ui/ViewWidget.cpp
+++ b/src/ui/ViewWidget.cpp
@@ -193,7 +193,7 @@ void ViewWidget::drawRenditionInfo(QPainter &painter)
 
   auto renditions               = manifest->getRenditionInfos();
   auto currentTargetRendition   = manifest->getCurrentRencodition();
-  auto currentPlaybackRendition = this->curFrame.segment->playbackInfo.rendition;
+  auto currentPlaybackRendition = this->curFrame.segment->segmentInfo.rendition;
 
   const auto arrawText     = "-->";
   const auto arrowTextSize = QFontMetrics(painter.font()).size(0, arrawText);


### PR DESCRIPTION
Work: 
 - Add rudimentary support for the adaptive resolution switching between renditions that vvdec and VVC support
 - Don't reallocate (kill/create) the decoder for decoding of each segment. We can just continue decoding (as long as we don't change renditions). This saves some time.
 - Recycle segment and frame storage in a circular buffer. This minimizes memory allocations. Us unique pointers with clear ownership for this.
 - Fix a memory leak where frames were not unreffed. This was not such a big problem when the decoder was reset for every segment.